### PR TITLE
Add new GitHub Action job to verify the build step

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -58,3 +58,19 @@ jobs:
       - run: npm ci
       - run: npx playwright install-deps
       - run: npm test
+
+  build:
+    name: Build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build --workspaces


### PR DESCRIPTION
This will help us avoid problems when publishing new components, as has happened with the Navbar.

In fact, it should fail until we merge this other PR: #31