### PR TITLE
test: collect and display coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ components/**/*.js
 components/**/*.js.map
 !components/icons.d.ts
 !components/scss.d.ts
+coverage
 storybook-static/

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "storybook:build": "build-storybook",
     "storybook:build:start": "web-dev-server --root-dir storybook-static --open",
     "storybook:start": "web-dev-server --config wds-storybook.config.js",
-    "test": "web-test-runner",
+    "test": "web-test-runner --coverage",
     "test:watch": "web-test-runner --watch"
   },
   "files": [


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

With this PR, we'll generate a coverage report when running the Test Runner tests, and also display the overall coverage in the console.

When developing locally, we can use `npm run test` to run tests and update the coverage report.

You can then open your locally generated `coverage/lcov-report/index.html` file and see a detailed coverage report.

---

Related to https://github.com/Qiskit/qiskit.org/issues/2699.