### PR TITLE
Emit click event for ui-shell nav items

### DIFF
--- a/.changeset/young-peas-film.md
+++ b/.changeset/young-peas-film.md
@@ -1,0 +1,5 @@
+---
+"@qiskit/web-components": patch
+---
+
+Emit click event for ui-shell nav items, passing the nav item label and url within the event detail.

--- a/components/ui-shell/header/header-menu-item-mega.ts
+++ b/components/ui-shell/header/header-menu-item-mega.ts
@@ -26,13 +26,30 @@ export class QiskitHeaderMenuItemMega extends LitElement {
         <ul class="qiskit-header-menu-item-mega-list">
           ${this.item?.children?.map((item) => {
             return html`<li>
-              <a href="${ifDefined(item?.url)}"> ${item.label} </a>
+              <a
+                href="${ifDefined(item?.url)}"
+                @click="${() => {
+                  this._handleClick(item.label);
+                }}"
+              >
+                ${item.label}
+              </a>
             </li>`;
           })}
         </ul>
       </div>
     `;
   }
+
+  _handleClick = (label: string) => {
+    this.dispatchEvent(
+      new CustomEvent('on-click', {
+        detail: { label },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  };
 }
 
 declare global {

--- a/components/ui-shell/header/header-menu-item-mega.ts
+++ b/components/ui-shell/header/header-menu-item-mega.ts
@@ -29,7 +29,7 @@ export class QiskitHeaderMenuItemMega extends LitElement {
               <a
                 href="${ifDefined(item?.url)}"
                 @click="${() => {
-                  this._handleClick(item.label);
+                  this._handleClick(item.label, item?.url);
                 }}"
               >
                 ${item.label}
@@ -41,10 +41,13 @@ export class QiskitHeaderMenuItemMega extends LitElement {
     `;
   }
 
-  _handleClick = (label: string) => {
+  _handleClick = (navItemLabel: string, navItemUrl: string) => {
     this.dispatchEvent(
       new CustomEvent('on-click', {
-        detail: { label },
+        detail: {
+          label: navItemLabel,
+          url: navItemUrl,
+        },
         bubbles: true,
         composed: true,
       })

--- a/components/ui-shell/header/header-menu-item-mega.ts
+++ b/components/ui-shell/header/header-menu-item-mega.ts
@@ -10,7 +10,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import styles from '../index.scss';
-import { NavItem } from '../settings.js';
+import type { NavItem } from '../settings.js';
 
 @customElement('qiskit-header-menu-item-mega')
 export class QiskitHeaderMenuItemMega extends LitElement {
@@ -29,7 +29,7 @@ export class QiskitHeaderMenuItemMega extends LitElement {
               <a
                 href="${ifDefined(item?.url)}"
                 @click="${() => {
-                  this._handleClick(item.label, item?.url);
+                  this._handleClick(item);
                 }}"
               >
                 ${item.label}
@@ -41,12 +41,12 @@ export class QiskitHeaderMenuItemMega extends LitElement {
     `;
   }
 
-  _handleClick = (navItemLabel: string, navItemUrl: string) => {
+  _handleClick = (item: NavItem) => {
     this.dispatchEvent(
       new CustomEvent('on-click', {
         detail: {
-          label: navItemLabel,
-          url: navItemUrl,
+          label: item.label,
+          url: item.url,
         },
         bubbles: true,
         composed: true,

--- a/components/ui-shell/index.scss
+++ b/components/ui-shell/index.scss
@@ -76,13 +76,13 @@ $prefix: "bx";
 #{$prefix}-header-name {
   &::part(link) {
     width: 8.75rem;
-    min-height: var(--header-height);
+    height: calc(var(--header-height) - 1px);
     fill: var(--cool-gray-80);
   }
 }
 
 #{$prefix}-header-nav {
-  height: auto;
+  height: calc(var(--header-height) - 1px);
 
   &::before,
   &::part(divider) {

--- a/components/ui-shell/index.stories.ts
+++ b/components/ui-shell/index.stories.ts
@@ -15,7 +15,7 @@ export default {
 
 export const Default = () =>
   html`<qiskit-ui-shell
-    @on-click="${(e) => {
+    @on-click="${(e: { detail: { label: string; url: string } }) => {
       alert(`label: ${e.detail?.label}, url: ${e.detail?.url}`);
     }}"
   ></qiskit-ui-shell>`;

--- a/components/ui-shell/index.stories.ts
+++ b/components/ui-shell/index.stories.ts
@@ -15,7 +15,7 @@ export default {
 
 export const Default = () =>
   html`<qiskit-ui-shell
-    @on-click="${(e: { detail: { label: string; url: string } }) => {
+    @on-click="${(e: CustomEvent) => {
       alert(`label: ${e.detail?.label}, url: ${e.detail?.url}`);
     }}"
   ></qiskit-ui-shell>`;

--- a/components/ui-shell/index.stories.ts
+++ b/components/ui-shell/index.stories.ts
@@ -21,4 +21,9 @@ export const Default = () =>
   ></qiskit-ui-shell>`;
 
 export const HideAccount = () =>
-  html`<qiskit-ui-shell variant="hide-account"></qiskit-ui-shell>`;
+  html`<qiskit-ui-shell
+    variant="hide-account"
+    @on-click="${(e: CustomEvent) => {
+      alert(`label: ${e.detail?.label}, url: ${e.detail?.url}`);
+    }}"
+  ></qiskit-ui-shell>`;

--- a/components/ui-shell/index.stories.ts
+++ b/components/ui-shell/index.stories.ts
@@ -13,7 +13,12 @@ export default {
   title: 'UI Shell',
 };
 
-export const Default = () => html`<qiskit-ui-shell></qiskit-ui-shell>`;
+export const Default = () =>
+  html`<qiskit-ui-shell
+    @on-click="${(e) => {
+      alert(`label: ${e.detail?.label}, url: ${e.detail?.url}`);
+    }}"
+  ></qiskit-ui-shell>`;
 
 export const HideAccount = () =>
   html`<qiskit-ui-shell variant="hide-account"></qiskit-ui-shell>`;

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -32,7 +32,7 @@ export class QiskitUIShell extends LitElement {
         <bx-header-name
           href="https://qiskit.org/"
           @click="${() => {
-            this._handleClick('Home');
+            this._handleClick('Home', 'https://qiskit.org');
           }}"
         >
           ${qiskitLogoIcon}
@@ -76,7 +76,7 @@ export class QiskitUIShell extends LitElement {
       <bx-header-nav-item
         href="${ifDefined(item?.url)}"
         @click="${() => {
-          this._handleClick(item?.label);
+          this._handleClick(item?.label, item?.url);
         }}"
       >
         ${item?.label}
@@ -111,7 +111,7 @@ export class QiskitUIShell extends LitElement {
       <bx-header-menu-item
         href="${ifDefined(item?.url)}"
         @click="${() => {
-          this._handleClick(item?.label);
+          this._handleClick(item?.label, item?.url);
         }}"
       >
         ${item?.label}
@@ -132,7 +132,7 @@ export class QiskitUIShell extends LitElement {
         href="https://learn.qiskit.org/account/"
         class="qiskit-user-accout-icon"
         @click="${() => {
-          this._handleClick('Account');
+          this._handleClick('Account', 'https://learn.qiskit.org/account/');
         }}"
       >
         ${userIcon}
@@ -155,7 +155,7 @@ export class QiskitUIShell extends LitElement {
       <bx-side-nav-link
         href="${ifDefined(item?.url)}"
         @click="${() => {
-          this._handleClick(item?.label);
+          this._handleClick(item?.label, item?.label);
         }}"
       >
         ${item?.label}
@@ -203,7 +203,7 @@ export class QiskitUIShell extends LitElement {
         href="${ifDefined(item?.url)}"
         class="${submenuClass}"
         @click="${() => {
-          this._handleClick(item?.label);
+          this._handleClick(item?.label, item?.url);
         }}"
       >
         ${item?.label}
@@ -217,7 +217,7 @@ export class QiskitUIShell extends LitElement {
         href="https://learn.qiskit.org/account/"
         class="qiskit-user-accout-icon"
         @click="${() => {
-          this._handleClick('Account');
+          this._handleClick('Account', 'https://learn.qiskit.org/account/');
         }}"
       >
         ${userIcon} <span>Profile</span>
@@ -225,10 +225,13 @@ export class QiskitUIShell extends LitElement {
     `;
   }
 
-  _handleClick = (label: string) => {
+  _handleClick = (navItemLabel: string, navItemUrl: string) => {
     this.dispatchEvent(
       new CustomEvent('on-click', {
-        detail: { label },
+        detail: {
+          label: navItemLabel,
+          url: navItemUrl,
+        },
         bubbles: true,
         composed: true,
       })

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -29,7 +29,12 @@ export class QiskitUIShell extends LitElement {
   render() {
     return html`
       <bx-header aria-label="Qiskit">
-        <bx-header-name href="https://qiskit.org/">
+        <bx-header-name
+          href="https://qiskit.org/"
+          @click="${() => {
+            this._handleClick('Home');
+          }}"
+        >
           ${qiskitLogoIcon}
         </bx-header-name>
         <bx-header-nav menu-bar-label="Qiskit">
@@ -116,12 +121,7 @@ export class QiskitUIShell extends LitElement {
 
   private _getHeaderMenuItemMega(item: NavItem) {
     return html`
-      <qiskit-header-menu-item-mega
-        .item="${item}"
-        @click="${() => {
-          this._handleClick(item?.label);
-        }}"
-      >
+      <qiskit-header-menu-item-mega .item="${item}">
       </qiskit-header-menu-item-mega>
     `;
   }

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -15,7 +15,8 @@ import './header/index.js';
 import { qiskitLogoIcon } from '../icons/qiskit-logo.js';
 import { userIcon } from '../icons/user.js';
 import styles from './index.scss';
-import { NavItem, TopLevelNavItem, Variant, NAV_ITEMS } from './settings.js';
+import { Variant, NAV_ITEMS } from './settings.js';
+import type { NavItem, TopLevelNavItem } from './settings.js';
 
 @customElement('qiskit-ui-shell')
 export class QiskitUIShell extends LitElement {
@@ -32,7 +33,10 @@ export class QiskitUIShell extends LitElement {
         <bx-header-name
           href="https://qiskit.org/"
           @click="${() => {
-            this._handleClick('Home', 'https://qiskit.org');
+            this._handleClick({
+              label: 'Home',
+              url: 'https://qiskit.org',
+            });
           }}"
         >
           ${qiskitLogoIcon}
@@ -76,7 +80,7 @@ export class QiskitUIShell extends LitElement {
       <bx-header-nav-item
         href="${ifDefined(item?.url)}"
         @click="${() => {
-          this._handleClick(item?.label, item?.url);
+          this._handleClick(item);
         }}"
       >
         ${item?.label}
@@ -111,7 +115,7 @@ export class QiskitUIShell extends LitElement {
       <bx-header-menu-item
         href="${ifDefined(item?.url)}"
         @click="${() => {
-          this._handleClick(item?.label, item?.url);
+          this._handleClick(item);
         }}"
       >
         ${item?.label}
@@ -132,7 +136,10 @@ export class QiskitUIShell extends LitElement {
         href="https://learn.qiskit.org/account/"
         class="qiskit-user-accout-icon"
         @click="${() => {
-          this._handleClick('Account', 'https://learn.qiskit.org/account/');
+          this._handleClick({
+            label: 'Account',
+            url: 'https://learn.qiskit.org/account/',
+          });
         }}"
       >
         ${userIcon}
@@ -155,7 +162,7 @@ export class QiskitUIShell extends LitElement {
       <bx-side-nav-link
         href="${ifDefined(item?.url)}"
         @click="${() => {
-          this._handleClick(item?.label, item?.label);
+          this._handleClick(item);
         }}"
       >
         ${item?.label}
@@ -203,7 +210,7 @@ export class QiskitUIShell extends LitElement {
         href="${ifDefined(item?.url)}"
         class="${submenuClass}"
         @click="${() => {
-          this._handleClick(item?.label, item?.url);
+          this._handleClick(item);
         }}"
       >
         ${item?.label}
@@ -217,7 +224,10 @@ export class QiskitUIShell extends LitElement {
         href="https://learn.qiskit.org/account/"
         class="qiskit-user-accout-icon"
         @click="${() => {
-          this._handleClick('Account', 'https://learn.qiskit.org/account/');
+          this._handleClick({
+            label: 'Account',
+            url: 'https://learn.qiskit.org/account/',
+          });
         }}"
       >
         ${userIcon} <span>Profile</span>
@@ -225,12 +235,12 @@ export class QiskitUIShell extends LitElement {
     `;
   }
 
-  _handleClick = (navItemLabel: string, navItemUrl: string) => {
+  _handleClick = (item: NavItem) => {
     this.dispatchEvent(
       new CustomEvent('on-click', {
         detail: {
-          label: navItemLabel,
-          url: navItemUrl,
+          label: item.label,
+          url: item.url,
         },
         bubbles: true,
         composed: true,

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -68,7 +68,12 @@ export class QiskitUIShell extends LitElement {
 
   private _getHeaderNavItem(item: NavItem) {
     return html`
-      <bx-header-nav-item href="${ifDefined(item?.url)}">
+      <bx-header-nav-item
+        href="${ifDefined(item?.url)}"
+        @click="${() => {
+          this._handleClick(item?.label);
+        }}"
+      >
         ${item?.label}
       </bx-header-nav-item>
     `;
@@ -98,7 +103,12 @@ export class QiskitUIShell extends LitElement {
 
   private _getHeaderMenuItem(item: NavItem) {
     return html`
-      <bx-header-menu-item href="${ifDefined(item?.url)}">
+      <bx-header-menu-item
+        href="${ifDefined(item?.url)}"
+        @click="${() => {
+          this._handleClick(item?.label);
+        }}"
+      >
         ${item?.label}
       </bx-header-menu-item>
     `;
@@ -134,7 +144,12 @@ export class QiskitUIShell extends LitElement {
 
   private _getSideNavLink(item: NavItem) {
     return html`
-      <bx-side-nav-link href="${ifDefined(item?.url)}">
+      <bx-side-nav-link
+        href="${ifDefined(item?.url)}"
+        @click="${() => {
+          this._handleClick(item?.label);
+        }}"
+      >
         ${item?.label}
       </bx-side-nav-link>
       <bx-side-nav-divider></bx-side-nav-divider>
@@ -179,6 +194,9 @@ export class QiskitUIShell extends LitElement {
       <bx-side-nav-menu-item
         href="${ifDefined(item?.url)}"
         class="${submenuClass}"
+        @click="${() => {
+          this._handleClick(item?.label);
+        }}"
       >
         ${item?.label}
       </bx-side-nav-menu-item>
@@ -190,11 +208,24 @@ export class QiskitUIShell extends LitElement {
       <bx-side-nav-link
         href="https://learn.qiskit.org/account/"
         class="qiskit-user-accout-icon"
+        @click="${() => {
+          this._handleClick('Account');
+        }}"
       >
         ${userIcon} <span>Profile</span>
       </bx-side-nav-link>
     `;
   }
+
+  _handleClick = (label: string) => {
+    this.dispatchEvent(
+      new CustomEvent('onClick', {
+        detail: { label },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  };
 }
 
 declare global {

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -227,7 +227,7 @@ export class QiskitUIShell extends LitElement {
 
   _handleClick = (label: string) => {
     this.dispatchEvent(
-      new CustomEvent('onClick', {
+      new CustomEvent('on-click', {
         detail: { label },
         bubbles: true,
         composed: true,

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -116,7 +116,12 @@ export class QiskitUIShell extends LitElement {
 
   private _getHeaderMenuItemMega(item: NavItem) {
     return html`
-      <qiskit-header-menu-item-mega .item="${item}">
+      <qiskit-header-menu-item-mega
+        .item="${item}"
+        @click="${() => {
+          this._handleClick(item?.label);
+        }}"
+      >
       </qiskit-header-menu-item-mega>
     `;
   }
@@ -126,6 +131,9 @@ export class QiskitUIShell extends LitElement {
       <bx-header-nav-item
         href="https://learn.qiskit.org/account/"
         class="qiskit-user-accout-icon"
+        @click="${() => {
+          this._handleClick('Account');
+        }}"
       >
         ${userIcon}
       </bx-header-nav-item>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qiskit/web-components",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qiskit/web-components",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@carbon/colors": "^10.37.1",


### PR DESCRIPTION
## Changes

Fixes #141 

## Implementation details
- added a customEvent "onClick", so projects can attach their own click event (`@on-click="myFunction"`)
- the intention is to give consumers of the web-component, a way to do something based off of nav item clicks

For example:
```vue
<qiskit-ui-shell @on-click="myClickFunction"></qiskit-ui-shell>
```


## Screenshots

https://user-images.githubusercontent.com/6276074/190003310-772698bf-8f4d-44c0-b89d-126528d91e4e.mov

