### PR TITLE
style: use css variable for max-width

### DIFF
--- a/.changeset/quick-actors-relax.md
+++ b/.changeset/quick-actors-relax.md
@@ -1,0 +1,5 @@
+---
+'@qiskit/web-components': patch
+---
+
+Update the header content max-width value to use a CSS variables. This will allow greater flexibility when this header is consumed in different areas of qiskit. eg platypus vs qiskit.org

--- a/components/ui-shell/index.scss
+++ b/components/ui-shell/index.scss
@@ -15,6 +15,7 @@ $prefix: "bx";
 
 :host {
   --header-height: 3.5rem;
+  --header-content-max-width: none;
   --cool-gray-10: #{$carbon--cool-gray-10};
   --cool-gray-20: #{$carbon--cool-gray-20};
   --cool-gray-30: #{$carbon--cool-gray-30};
@@ -67,7 +68,7 @@ $prefix: "bx";
     display: flex;
     justify-content: space-between;
     width: 100%;
-    max-width: 99rem;
+    max-width: var(--header-content-max-width);
     margin-right: auto;
     margin-left: auto;
   }

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -57,7 +57,11 @@ export class QiskitUIShell extends LitElement {
         </div>
       </bx-header>
 
-      <bx-side-nav aria-label="Main mobile navigation" usage-mode="header-nav">
+      <bx-side-nav
+        aria-label="Main mobile navigation"
+        usage-mode="header-nav"
+        tabindex="-1"
+      >
         <bx-side-nav-items>
           ${this._getSideNavItems()}
           ${this.variant === Variant.HIDE_ACCOUNT


### PR DESCRIPTION
## Changes
Update to use a css variable to determine max width for the header content. This will allow more flexibility when used in qiskit.org, platypus and others. Defaults to none.

As I started integration of the ui-shell in [qiskit.org](https://github.com/Qiskit/qiskit.org/pull/2784) and [platypus](https://github.com/Qiskit/platypus/pull/1555), I ran into issues with the alignment of header items. on qiskit.org for example, the header content is flush to the page content (has a max width set). On the learn.qiskit.org pages (platypus) there is no max width and the navigation items on the right are flush against the right side of the screen. 

This PR also includes a change that sets the tabindex of the sidenav to -1. This will ensure that the items in the sidenav will not be accessible via keyboard when it isn't visible (desktop view/larger screens). This does not interfere with the auto focus placed inside the mobile nav when it is expanded.

Resolves #152 

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details
This approach will allow greater styling flexibility from where the header is being consumed.

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

## How to read this PR

<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots

Screenshots showing the different max-width constraints in the app header for qiskit.org vs platypus

<img width="1667" alt="Screen Shot 2022-09-15 at 12 09 59 PM" src="https://user-images.githubusercontent.com/8097306/190489329-50aa5672-37fb-454e-baa1-91472426c2f6.png">
<img width="1680" alt="Screen Shot 2022-09-15 at 12 11 05 PM" src="https://user-images.githubusercontent.com/8097306/190489333-39554308-00d6-4419-adde-962514312273.png">

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
