### PR TITLE
fix(ui-shell): fix typo and address a11y violation

### DIFF
--- a/.changeset/hungry-plants-cough.md
+++ b/.changeset/hungry-plants-cough.md
@@ -1,0 +1,5 @@
+---
+'@qiskit/web-components': patch
+---
+
+Fixes 'Qiskit textboox' typo

--- a/.changeset/rich-balloons-begin.md
+++ b/.changeset/rich-balloons-begin.md
@@ -1,0 +1,5 @@
+---
+'@qiskit/web-components': patch
+---
+
+Address a11y landmark violation

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -68,7 +68,7 @@ export class QiskitUIShell extends LitElement {
             ? null
             : this._getAccountSideNavLink()}
         </bx-side-nav-items>
-        <footer class="qiskit-side-nav-footer">
+        <div class="qiskit-side-nav-footer">
           <div class="qiskit-side-nav-footer__social-container">
             <p class="qiskit-side-nav-footer__social-heading">Stay connected</p>
             <div class="qiskit-side-nav-footer__social-icons">
@@ -78,7 +78,7 @@ export class QiskitUIShell extends LitElement {
           <div class="qiskit-side-nav-footer__copyright">
             © Qiskit | All Rights Reserved
           </div>
-        </footer>
+        </div>
       </bx-side-nav>
     `;
   }

--- a/components/ui-shell/settings.ts
+++ b/components/ui-shell/settings.ts
@@ -193,7 +193,7 @@ export const NAV_ITEMS: TopLevelNavItem[] = [
             url: 'https://qiskit.slack.com/',
           },
           {
-            label: 'Qiskit textboox',
+            label: 'Qiskit Textbook',
             url: 'https://qiskit.org/learn/',
           },
         ],


### PR DESCRIPTION
## Changes
- Fix `textboox` > `Textbook`. 
- Updates `<footer>` component to div

Resolves #157
Resolves #155

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details
From my understanding of the [axe rule](https://dequeuniversity.com/rules/axe/4.4/landmark-contentinfo-is-top-level?application=axeAPI)  the footer landmark used in the sidenav is nested inside the CD web-component `side-nav` component which already has a `role=` attribute on the element.

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

## How to read this PR
Should be straightforward. I did not see any regressions with these changes
<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
