### PR TITLE
feat(ui-shell): add parent link prefix

### DIFF
--- a/.changeset/flat-rings-yawn.md
+++ b/.changeset/flat-rings-yawn.md
@@ -1,0 +1,5 @@
+---
+'@qiskit/web-components': patch
+---
+
+Update ui-shell click event to include parent dropdown label

--- a/components/ui-shell/header/header-menu-item-mega.ts
+++ b/components/ui-shell/header/header-menu-item-mega.ts
@@ -19,6 +19,9 @@ export class QiskitHeaderMenuItemMega extends LitElement {
   @property({ type: Object })
   item = {} as NavItem;
 
+  @property({ type: String })
+  parentLabel = '';
+
   render() {
     return html`
       <div class="qiskit-header-menu-item-mega">
@@ -45,7 +48,7 @@ export class QiskitHeaderMenuItemMega extends LitElement {
     this.dispatchEvent(
       new CustomEvent('on-click', {
         detail: {
-          label: item.label,
+          label: `${this.parentLabel}-${item.label}`,
           url: item.url,
         },
         bubbles: true,

--- a/components/ui-shell/index.ts
+++ b/components/ui-shell/index.ts
@@ -114,7 +114,9 @@ export class QiskitUIShell extends LitElement {
           menu-label="${menu?.label}"
           trigger-content="${menu?.label}"
         >
-          ${menu?.children?.map((item) => this._getHeaderMenuItemMega(item))}
+          ${menu?.children?.map((item) =>
+            this._getHeaderMenuItemMega(item, menu?.label)
+          )}
         </qiskit-header-menu-mega>
       `;
     }
@@ -123,17 +125,19 @@ export class QiskitUIShell extends LitElement {
         menu-label="${menu?.label}"
         trigger-content="${menu?.label}"
       >
-        ${menu?.children?.map((item) => this._getHeaderMenuItem(item))}
+        ${menu?.children?.map((item) =>
+          this._getHeaderMenuItem(item, menu?.label)
+        )}
       </qiskit-header-menu>
     `;
   }
 
-  private _getHeaderMenuItem(item: NavItem) {
+  private _getHeaderMenuItem(item: NavItem, parentLabel: string) {
     return html`
       <bx-header-menu-item
         href="${ifDefined(item?.url)}"
         @click="${() => {
-          this._handleClick(item);
+          this._handleClick(item, parentLabel);
         }}"
       >
         ${item?.label}
@@ -141,9 +145,12 @@ export class QiskitUIShell extends LitElement {
     `;
   }
 
-  private _getHeaderMenuItemMega(item: NavItem) {
+  private _getHeaderMenuItemMega(item: NavItem, parentLabel: string) {
     return html`
-      <qiskit-header-menu-item-mega .item="${item}">
+      <qiskit-header-menu-item-mega
+        .item="${item}"
+        .parentLabel="${parentLabel}"
+      >
       </qiskit-header-menu-item-mega>
     `;
   }
@@ -202,7 +209,7 @@ export class QiskitUIShell extends LitElement {
                 class="qiskit-side-nav-submenu"
               >
                 ${submenuItem?.children?.map((child) =>
-                  this._getSideNavMenuItem(child, true)
+                  this._getSideNavMenuItem(child, menu?.label, true)
                 )}
               </bx-side-nav-menu>
             `;
@@ -213,13 +220,19 @@ export class QiskitUIShell extends LitElement {
     }
     return html`
       <bx-side-nav-menu title="${menu?.label}">
-        ${menu?.children?.map((item) => this._getSideNavMenuItem(item))}
+        ${menu?.children?.map((item) =>
+          this._getSideNavMenuItem(item, menu?.label)
+        )}
       </bx-side-nav-menu>
       <bx-side-nav-divider></bx-side-nav-divider>
     `;
   }
 
-  private _getSideNavMenuItem(item: NavItem, isSubmenuItem = false) {
+  private _getSideNavMenuItem(
+    item: NavItem,
+    parentLabel: string,
+    isSubmenuItem = false
+  ) {
     const submenuClass = isSubmenuItem
       ? 'qiskit-nav-submenu-item'
       : 'qiskit-nav-menu-item';
@@ -228,7 +241,7 @@ export class QiskitUIShell extends LitElement {
         href="${ifDefined(item?.url)}"
         class="${submenuClass}"
         @click="${() => {
-          this._handleClick(item);
+          this._handleClick(item, parentLabel);
         }}"
       >
         ${item?.label}
@@ -270,11 +283,13 @@ export class QiskitUIShell extends LitElement {
     );
   }
 
-  _handleClick = (item: NavItem) => {
+  _handleClick = (item: NavItem, parentLabel?: string) => {
+    const label = parentLabel ? `${parentLabel}-${item.label}` : item.label;
+
     this.dispatchEvent(
       new CustomEvent('on-click', {
         detail: {
-          label: item.label,
+          label,
           url: item.url,
         },
         bubbles: true,

--- a/components/ui-shell/settings.ts
+++ b/components/ui-shell/settings.ts
@@ -9,7 +9,6 @@ interface NavItem {
   label: string;
   url?: string;
   children?: NavItem[];
-  segment?: SegmentData;
 }
 
 interface TopLevelNavItem extends NavItem {
@@ -18,11 +17,6 @@ interface TopLevelNavItem extends NavItem {
 
 interface SocialLinks extends NavItem {
   icon: TemplateResult;
-}
-
-interface SegmentData {
-  cta: string;
-  location: string;
 }
 
 export enum Variant {


### PR DESCRIPTION
## Changes
Adds the parent link label as a prefix to the onclick event label. This will differentiate the top level "Overview" link from the Documentation "Overview" link. The new nested link will emit the label "Documentation-Overview"

Also removes unused segment interface.

Resolves #161

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details
Pass the top-level parent label to all nested links . This should be working for desktop/tablet/mobile views. This will ensure any nested links (including ones in the `Community` dropdown) will have the parent label prefixed.

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

## How to read this PR

<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots

https://user-images.githubusercontent.com/8097306/191085492-5dbcc70f-0ffe-484c-baaf-cd5c0361b59c.mov



<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
