### PR TITLE
Build experimental-bundled-ui-shell.js as immediately invoked function expression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qiskit/web-components",
-  "version": "0.11.2",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qiskit/web-components",
-      "version": "0.11.2",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@carbon/colors": "^10.37.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -59,7 +59,7 @@ export default [
     ],
     output: {
       file: 'experimental-bundled-ui-shell.js',
-      format: 'esm',
+      format: 'iife',
     },
   },
 ];


### PR DESCRIPTION
## Changes

As found in https://github.com/Qiskit/qiskit_sphinx_theme/pull/274#issuecomment-1515527247, we want to bundle web components into qiskit_sphinx_theme as immediately invoked function expressions. That allows us to avoid issues with CORS on local development & results in the component being immediately loaded, rather than having a delay.

## Implementation details

See https://rollupjs.org/configuration-options/#output-format for the relevant docs.

According to Abdón, `experimental-bundled-ui-shell.js` is only used by `qiskit_sphinx_theme`, so this should have no impact on other teams. It will not change e.g. how `npm install` works, as far as I can tell.